### PR TITLE
Turn on controls in example players

### DIFF
--- a/video-element/getting-started.md
+++ b/video-element/getting-started.md
@@ -21,7 +21,7 @@ To monitor the performance of a specific video element, call <code>mux.monitor</
 
 ```html
 <!-- Example html video element -->
-<video id="myVideo">
+<video id="myVideo" controls>
   <source src="//path/to/video.mp4" type="video/mp4">
 </video>
 

--- a/videojs/getting-started.md
+++ b/videojs/getting-started.md
@@ -63,7 +63,7 @@ videojs('my-player', {
 
 ```html
 <!-- OR in the data-setup attribute of the video.js element -->
-<video id="my-player"
+<video id="my-player" controls
   data-setup='{"plugins": {"mux": {"debug": false, "data": { ... }}}}' >
   ...
 </video>


### PR DESCRIPTION
When walking through setup with Steven he was copying the example code exactly, and it made it clear that controls would be useful on the example video element.